### PR TITLE
feat: DTO字段检测解决极端情况下部分实体无法成功匹配

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,11 @@ intellij {
 }
 dependencies {
 //    implementation("com.intellij:forms_rt:7.0.3")
-    implementation("cn.hutool:hutool-core:5.8.22")
+    implementation("cn.hutool:hutool-core:5.8.25")
     implementation("com.alibaba.fastjson2:fastjson2:2.0.41")
+
+    implementation ("ch.qos.logback:logback-classic:1.4.12") // Logback 依赖
+    implementation ("org.slf4j:slf4j-api:1.7.30") // SLF4J API 依赖
 
     // 引入 lombok
     compileOnly("org.projectlombok:lombok:1.18.34")

--- a/src/main/java/com/easy/query/plugin/core/util/PsiJavaClassUtil.java
+++ b/src/main/java/com/easy/query/plugin/core/util/PsiJavaClassUtil.java
@@ -1,21 +1,29 @@
 package com.easy.query.plugin.core.util;
 
 import cn.hutool.core.util.ReUtil;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiJavaFile;
+import com.google.common.collect.Lists;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.source.PsiJavaFileImpl;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.psi.javadoc.PsiInlineDocTag;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Collectors;
 
+/**
+ * PsiJavaClass 工具类
+ *
+ * @author link2fun
+ */
+@Slf4j
 public class PsiJavaClassUtil {
 
     /**
      * 获取 @link 注解的类
-     * 
+     *
      * @param currentClass 当前类
      * @return {@code PsiClass}
      */
@@ -29,7 +37,7 @@ public class PsiJavaClassUtil {
 
     /**
      * 获取 @link 注解的类名称(全限定名)
-     * 
+     *
      * @param currentClass 当前类
      * @return {@code String}
      */
@@ -55,17 +63,17 @@ public class PsiJavaClassUtil {
         // 这个 mainEntityClassFromLink 就是我们要找的主实体类, 但是可能不包含包名
         if (!cn.hutool.core.util.StrUtil.contains(mainEntityClassFromLink, ".")) {
             // 没有包含 . 说明没有包名, 需要从上下文中提取, 优先从 import 中提取
-            Set<String> importSet = PsiJavaFileUtil
-                    .getQualifiedNameImportSet((PsiJavaFile) currentClass.getContainingFile());
-            for (String importStr : importSet) {
+            List<String> importList = getImportLinesQualifiedName(currentClass);
+            for (String importStr : importList) {
                 if (importStr.endsWith("." + mainEntityClassFromLink)) {
                     mainEntityClassQualifiedName = importStr;
                     break;
                 } else if (importStr.endsWith(".*")) {
-                    String portableClass = importStr.substring(0, importStr.length() - 1) + mainEntityClassFromLink;
-                    if (PsiJavaFileUtil.getPsiClass(currentClass.getProject(), portableClass) != null) {
-                        mainEntityClassQualifiedName = portableClass;
+                    String portableClassName = importStr.substring(0, importStr.length() - 1) + mainEntityClassFromLink;
+                    if (PsiJavaFileUtil.getPsiClass(currentClass.getProject(), portableClassName) != null) {
+                        mainEntityClassQualifiedName = portableClassName;
                         break;
+                    } else {
                     }
                 }
             }
@@ -75,4 +83,56 @@ public class PsiJavaClassUtil {
 
         return mainEntityClassQualifiedName; // 返回主实体类的完全限定名
     }
+
+
+    /**
+     * 从 PsiClass 中提取 import 行信息, 未经解析
+     * eg: import xx.xx;
+     *
+     * @param psiClass {@code PsiClass}
+     */
+    public List<String> getImportLines(final PsiClass psiClass) {
+        PsiImportList importList = ((PsiJavaFileImpl) psiClass.getContainingFile()).getImportList();
+        if (Objects.isNull(importList)) {
+            return Lists.newArrayList();
+        }
+        return Arrays.stream(importList.getAllImportStatements()).map(PsiElement::getText).collect(Collectors.toList());
+    }
+
+
+    /**
+     * 从 PsiClass 中提取 import 的全限定名
+     * eg: import com.easyquery -> com.easyquery
+     */
+    public static List<String> getImportLinesQualifiedName(final PsiClass psiClass) {
+        PsiImportList importList = ((PsiJavaFileImpl) psiClass.getContainingFile()).getImportList();
+        if (Objects.isNull(importList)) {
+            return Lists.newArrayList();
+        }
+
+        return Arrays.stream(importList.getAllImportStatements())
+                .map(statement -> {
+                    return Arrays.stream(statement.getChildren())
+                            // 过滤掉关键字 import
+                            .filter(child -> {
+                                if (child instanceof PsiKeyword) {
+                                    // 不要 keyword 这里面一般是 import
+                                    return false;
+                                } else if (child instanceof PsiJavaToken) {
+                                    // 过滤掉一些特殊字符
+                                    if (StrUtil.equalsAny(child.getText(), ";", " ")) {
+                                        return false;
+                                    }
+                                }
+                                // 剩下的都要
+                                return true;
+                            })
+                            .map(PsiElement::getText) // 提取元素文本
+                            .collect(Collectors.joining(""));
+                })
+                .map(StrUtil::trimToEmpty) // 拼接后去掉首尾空格
+                .filter(StrUtil::isNotBlank) // 过滤掉空行
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
PsiJavaFileUtil.getQualifiedNameImportSet
某些情况下会少信息， 导致检测失败
